### PR TITLE
fixed a corner case where remLen was not checked and buffer overflow …

### DIFF
--- a/src/json-maker.c
+++ b/src/json-maker.c
@@ -146,9 +146,10 @@ static char* atoesc( char* dest, char const* src, int len, size_t* remLen  ) {
                 *dest++ = '\\';
                 --*remLen;
                 int const esc = escape( src[i] );
-                if ( esc )
-                    *dest = esc;
-                else {
+                if ( esc ) {
+                    if (*remLen != 0)
+                        *dest = esc;
+                } else {
                     if (*remLen != 0) {
                         --*remLen;
                         *dest++ = 'u';
@@ -172,6 +173,9 @@ static char* atoesc( char* dest, char const* src, int len, size_t* remLen  ) {
                 }
             }
         }
+
+        if (*remLen == 0)
+            break;
     }
     *dest = '\0';
     return dest;


### PR DESCRIPTION
In function `atoesc()`, the `remLen` was decremented **_in_** the for loop statement as well as **_inside_** the for loop when a character was escaped. In case remLen becomes 0 inside the for loop, it was decremented again in the for loop statement. Since remLen is of type size_t, this led to remLen becoming UINT_MAX and continue the loop causing a buffer overflow.